### PR TITLE
Don't polyfill `asyncIterator` if it's readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,10 @@
   "convenience methods" for various operators (_e.g._, the `map` in `xs.map(x =>
   x)`).
 
+### Improvements
+
+- Minor fix in polyfill code for `asyncIterable`: don't polyfill on objects where the property is
+  readonly.
+
 [linq-ops]: https://docs.microsoft.com/en-us/previous-versions/dotnet/articles/bb394939(v=msdn.10)
 [async-iter]: https://github.com/tc39/proposal-async-iteration

--- a/nodejs/query/index.ts
+++ b/nodejs/query/index.ts
@@ -21,7 +21,9 @@
 // Polyfill the async iterator per the "caveats" section of the feature release notes:
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#the-for-await-of-statement
 //
-(Symbol as any).asyncIterator = Symbol.asyncIterator || Symbol.for("Symbol.asyncIterator");
+if (typeof (Symbol as any).asyncIterator === "undefined") {
+    (Symbol as any).asyncIterator = Symbol.asyncIterator || Symbol.for("Symbol.asyncIterator");
+}
 
 import { AsyncQueryableImpl } from "./asyncQueryable";
 import { AsyncQueryable, AsyncQuerySource } from "./interfaces";


### PR DESCRIPTION
Guards against errors like:

```
/Users/alex/go/src/github.com/pulumi/pulumi/sdk/nodejs/node_modules/@pulumi/query/index.js:36
Symbol.asyncIterator = Symbol.asyncIterator || Symbol.for("Symbol.asyncIterator");
                     ^
TypeError: Cannot assign to read only property 'asyncIterator' of function 'function Symbol() { [native code] }'
    at Object.<anonymous> (/Users/alex/go/src/github.com/pulumi/pulumi/sdk/nodejs/node_modules/@pulumi/query/index.js:36:22)
```