### PR TITLE
Add stand-in type definitions for es2018.asynciterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## Unreleased
+## v0.2.0
+
+### Improvements
+
+- Don't require users to supply `es2018.asynciterable` to `.compilationOptions.libs` when compiling
+  against this library.
+
+## v0.1.0
 
 ### Major Changes
 

--- a/nodejs/query/asyncQueryable.ts
+++ b/nodejs/query/asyncQueryable.ts
@@ -14,6 +14,7 @@
 
 import { IterableBase } from "./base";
 import {
+    AsyncIterableIterator,
     AsyncQueryable,
     AsyncQueryableGrouping,
     AsyncQuerySource,

--- a/nodejs/query/base.ts
+++ b/nodejs/query/base.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GroupedAsyncIterableIterator } from "./interfaces";
+import { AsyncIterableIterator, GroupedAsyncIterableIterator } from "./interfaces";
 
 export abstract class IterableBase<T> implements AsyncIterableIterator<T> {
     constructor(private readonly core: AsyncIterableIterator<T>) {}

--- a/nodejs/query/index.ts
+++ b/nodejs/query/index.ts
@@ -26,7 +26,7 @@ if (typeof (Symbol as any).asyncIterator === "undefined") {
 }
 
 import { AsyncQueryableImpl } from "./asyncQueryable";
-import { AsyncQueryable, AsyncQuerySource } from "./interfaces";
+import { AsyncIterableIterator, AsyncQueryable, AsyncQuerySource } from "./interfaces";
 import * as sources from "./sources";
 
 export { AsyncQueryable, AsyncQueryableGrouping, OrderKey } from "./interfaces";

--- a/nodejs/query/interfaces.ts
+++ b/nodejs/query/interfaces.ts
@@ -12,6 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+///////////////////////////////////////////////////////////////////////////////
+
+// es2018.asynciterator types.
+//
+// Type definitions contained in the `es2018.asynciterable` library. These are
+// included here so that users do not have to add this string to
+// `.compilationOptions.libs`.
+
+///////////////////////////////////////////////////////////////////////////////
+
+export interface AsyncIterator<T> {
+    next(value?: any): Promise<IteratorResult<T>>;
+    return?(value?: any): Promise<IteratorResult<T>>;
+    throw?(e?: any): Promise<IteratorResult<T>>;
+}
+
+export interface AsyncIterable<T> {
+    [Symbol.asyncIterator](): AsyncIterator<T>;
+}
+
+export interface AsyncIterableIterator<T> extends AsyncIterator<T> {
+    [Symbol.asyncIterator](): AsyncIterableIterator<T>;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 export function isAsyncIterable<T>(o: any): o is AsyncIterable<T> {
     return typeof o[Symbol.asyncIterator] === "function";
 }

--- a/nodejs/query/operators.ts
+++ b/nodejs/query/operators.ts
@@ -15,6 +15,8 @@
 import { isBoolean, isNumber, isString } from "util";
 import { GroupedAsyncIterableIteratorImpl } from "./base";
 import {
+    AsyncIterable,
+    AsyncIterableIterator,
     AsyncQuerySource,
     Evaluator,
     GroupedAsyncIterableIterator,
@@ -846,7 +848,7 @@ export async function* zip<TSource1, TSource2, TResult = [TSource1, TSource2]>(
     source2: AsyncIterableIterator<TSource2>,
     resultSelector: (t1: TSource1, t2: TSource2) => TResult | Promise<TResult> = (t1, t2) =>
         <TResult>(<unknown>[t1, t2]),
-) {
+): AsyncIterableIterator<TResult> {
     while (true) {
         const result1 = await source1.next();
         const result2 = await source2.next();

--- a/nodejs/query/sources.ts
+++ b/nodejs/query/sources.ts
@@ -12,10 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { AsyncQuerySource, isAsyncIterable } from "./interfaces";
+import {
+    AsyncIterable,
+    AsyncIterableIterator,
+    AsyncQuerySource,
+    isAsyncIterable,
+} from "./interfaces";
 import { isIterable } from "./util";
 
-export async function* range(start: number, end?: number) {
+export async function* range(start: number, end?: number): AsyncIterableIterator<number> {
     let i = start;
     while (true) {
         if (end !== undefined && i >= end) {

--- a/nodejs/query/tsconfig.json
+++ b/nodejs/query/tsconfig.json
@@ -1,8 +1,7 @@
 {
-    "lib": ["esnext.asynciterable"],
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es5",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,
@@ -15,6 +14,7 @@
         "noImplicitReturns": true,
         "forceConsistentCasingInFileNames": true,
         "strictNullChecks": true,
+        "downlevelIteration": true,
     },
     "files": [
         "asyncQueryable.ts",

--- a/nodejs/query/util.ts
+++ b/nodejs/query/util.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { AsyncIterable } from "./interfaces";
+
 export function isAsyncIterable<T>(o: any): o is AsyncIterable<T> {
     return typeof o[Symbol.asyncIterator] === "function";
 }


### PR DESCRIPTION
Async iterators were standardized as part of the ES2018 specification.
Unfortunately for TypeScript users of this library, this typically means
adding `es2018.asynciterator` to `.compilerOptions.libs` in your
`tsconfig.json`.

This is a bad experience for users. Since that library contains only
type definitions for async iterators, we define them in our project here
to avoid asking users to do this.