### PR TITLE
Declare `SymbolConstructor` for older versions of ES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.3.0
+
+### Improvements
+
+- Re-declare the global `SymbolConstructor` with `asyncIterator`, allowing users targeting ES
+  versions earlier than the 2018 to use this library.
+
+
 ## v0.2.0
 
 ### Improvements

--- a/nodejs/query/interfaces.ts
+++ b/nodejs/query/interfaces.ts
@@ -22,6 +22,12 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
+declare global {
+    export interface SymbolConstructor {
+        readonly asyncIterator: symbol;
+    }
+}
+
 export interface AsyncIterator<T> {
     next(value?: any): Promise<IteratorResult<T>>;
     return?(value?: any): Promise<IteratorResult<T>>;

--- a/nodejs/query/tsconfig.json
+++ b/nodejs/query/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es5",
+        "target": "es6",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,
@@ -14,7 +14,6 @@
         "noImplicitReturns": true,
         "forceConsistentCasingInFileNames": true,
         "strictNullChecks": true,
-        "downlevelIteration": true,
     },
     "files": [
         "asyncQueryable.ts",


### PR DESCRIPTION
Older versions of the ES standard do not define `Symbol#asyncIterator`.
This means our attempts to "manually" define `AsyncIterator` for
versions of ES that don't have it fail.

Following [1] and [2], our understanding is that the best existing
solution is to manually re-define `SymbolConstructor` to have this
member.

[1]: https://github.com/Microsoft/TypeScript/issues/13031
[2]: https://github.com/microsoft/TypeScript/issues/8099